### PR TITLE
投稿一覧のフッターの高さ揃え

### DIFF
--- a/app/assets/stylesheets/post_form.css
+++ b/app/assets/stylesheets/post_form.css
@@ -49,8 +49,7 @@ label:has(input[value="thanks"]:checked) .card-ui {
   box-shadow: 0 6px 20px rgba(236, 72, 153, 0.25);
   transform: translateY(-5px);
 }
-
-   コメント設定／公開設定カード共通
+/* 選択時の枠強調 */
 .card-ui:has(input:checked) {
   border-color: #fb923c;
   box-shadow: 0 0 0 4px rgba(251, 146, 60, 0.2);

--- a/app/assets/stylesheets/posts.css
+++ b/app/assets/stylesheets/posts.css
@@ -1,12 +1,23 @@
-/* 投稿カード（一覧） */
+/* 投稿カードを並べるグリッド */
+.posts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+  align-items: stretch;
+}
+
+/* 投稿カード本体 */
 .post-card {
-  background: white;
+  background: #fff;
   border-radius: 16px;
   overflow: hidden;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   cursor: pointer;
   animation: fadeIn 0.5s ease-out;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .post-card:hover {
@@ -51,19 +62,18 @@
   color: #db2777;
 }
 
-.post-type {
-  font-size: 14px;
-}
-
-.post-date {
-  font-size: 12px;
-  opacity: 0.8;
-}
-
 /* 投稿本文 */
 .post-card-body {
   padding: 20px;
-  min-height: 120px;
+  flex-grow: 1; 
+  display: block;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 160px; 
+}
+
+.post-card-body > *:last-child {
+  margin-bottom: 0;
 }
 
 .post-title {
@@ -79,7 +89,14 @@
   line-height: 1.6;
   font-size: 15px;
   word-wrap: break-word;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
+
+
 
 /* 投稿フッター */
 .post-card-footer {
@@ -88,8 +105,13 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  background: #f9fafb;
+  min-height: 70px; 
+  height : 70px;
+  margin-top: auto; 
 }
 
+/* 投稿メタ情報 */
 .post-meta {
   display: flex;
   flex-direction: column;
@@ -111,14 +133,74 @@
   display: inline-block;
 }
 
-
-/* 不要カウント非表示設定 */
-.like-count,
-.comment-count {
-  display: none;
+/* ボタン領域 */
+.post-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  min-width: 80px;
+  min-height: 36px; /* ボタンがなくても高さを維持 */
 }
 
-/* ページネーション（Kaminari用） */
+/* コメントボタン */
+.comment-btn {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 4px;
+  background: #f9fafb;
+  border: none;
+  border-radius: 6%;
+  font-size: 10px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  color: #16a34a;
+}
+
+.comment-btn:hover {
+  background: #bbf7d0;
+  color: #065f46;
+  transform: scale(1.1);
+}
+
+.comment-btn span {
+  font-weight: bold;
+  font-size: 13px;
+}
+
+/* 花ボタン */
+.flower-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 50%;
+  background: #f9fafb;
+  color: #16a34a;
+  cursor: pointer;
+  font-size: 18px;
+  transition: all 0.2s ease-in-out;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+}
+
+.flower-btn:hover {
+  background: #bbf7d0;
+  color: #065f46;
+  transform: scale(1.1);
+}
+
+.flower-btn .flower-count {
+  font-weight: 600;
+  font-size: 13px;
+  margin-left: 4px;
+  color: #16a34a;
+}
+
+/* ページネーション */
 .pagination {
   display: flex;
   justify-content: center;
@@ -134,7 +216,7 @@
   font-weight: 500;
   font-size: 14px;
   color: #555;
-  background: white;
+  background: #fff;
   transition: all 0.3s;
 }
 
@@ -146,7 +228,7 @@
 
 .pagination .current {
   background: linear-gradient(135deg, #ffb3a4 0%, #ff9a8e 100%);
-  color: white;
+  color: #fff;
   border-color: #ff9a8e;
   box-shadow: 0 4px 10px rgba(255, 154, 142, 0.3);
 }
@@ -156,7 +238,7 @@
   cursor: not-allowed;
 }
 
-/* 絞り込み・ソート（投稿一覧上部） */
+/* 絞り込みバー */
 .filter-bar {
   display: flex;
   flex-wrap: wrap;
@@ -170,7 +252,7 @@
   margin-bottom: 32px;
 }
 
-/* 絞り込みボタン群 */
+/* 絞り込みボタン */
 .filter-buttons {
   display: flex;
   flex-wrap: wrap;
@@ -181,7 +263,7 @@
   padding: 8px 18px;
   border: 2px solid #e5e7eb;
   border-radius: 20px;
-  background: white;
+  background: #fff;
   color: #555;
   font-weight: 500;
   transition: all 0.3s ease;
@@ -220,68 +302,9 @@
   box-shadow: 0 0 4px rgba(255, 154, 142, 0.4);
 }
 
-/* ラベル類 */
+/* ラベル */
 .filter-label {
   font-weight: 600;
   color: #444;
   margin-right: 8px;
-}
-
-/* コメントボタン */
-.comment-btn {
-  display: flex;
-  align-items: center;
-  gap: 3px;
-  padding: 2px 4px;
-  background: #f9fafb;
-  border: none;
-  border-radius: 6%;
-  font-size: 10px;
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-  color: #16a34a; /* グリーン系 */
-}
-
-.comment-btn:hover {
-  background: #bbf7d0;
-  color: #065f46;
-  transform: scale(1.1);
-}
-
-.comment-btn span {
-  font-weight: bold;
-  font-size: 13px;
-}
-
-/* 花ボタン（いいね） */
-.flower-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 3px;
-  width: 36px;
-  height: 36px;
-  border: none;
-  border-radius: 50%; /* ←コメントボタンと形を完全一致 */
-  background: #f9fafb; /* ←baseトーンを合わせる */
-  color: #16a34a;
-  cursor: pointer;
-  font-size: 18px;
-  transition: all 0.2s ease-in-out;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
-}
-
-.flower-btn:hover {
-  background: #bbf7d0;
-  color: #065f46;
-  transform: scale(1.1);
-}
-
-
-/* ボタン内のカウント数字 */
-.flower-btn .flower-count {
-  font-weight: 600;
-  font-size: 13px;
-  margin-left: 4px;
-  color: #16a34a; 
 }

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -36,7 +36,7 @@
       <% end %>
     </div>
 
-    <div id="posts-grid" class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+    <div class="posts-grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
       <% @posts.each do |post| %>
         <div class="post-card bg-white rounded-3xl shadow-lg overflow-hidden hover:shadow-xl transition">
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,7 +3,6 @@
 require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
-  # 基本設定
   # コードを都度リロード
   config.cache_classes = false
   config.eager_load = false
@@ -38,14 +37,18 @@ Rails.application.configure do
   config.active_record.migration_error = :page_load
   config.active_record.verbose_query_logs = true
 
+  # アセット関連
   config.assets.paths += [
     Rails.root.join('app/assets/builds'),
     Rails.root.join('public/assets')
   ]
 
-  # 開発ではビルド済みアセットを直接配信
+  # 開発時：ビルド済みCSSを即反映
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    'Cache-Control' => 'public, max-age=31536000'
+    'Cache-Control' => 'public, max-age=0'
   }
+
+  config.assets.debug = true
+  config.assets.compile = true
 end


### PR DESCRIPTION
本実装では、投稿カード一覧のレイアウト崩れを防ぎ、フッターや本文の高さを統一して見やすいデザインに整えました。
まず、.posts-gridをgridレイアウトにして各カードを等間隔に配置し、.post-cardにflexを指定して縦方向の構造を安定化させています。
フッター部分（.post-card-footer）には固定のmin-height: 72pxを設定し、コメントボタンの有無に関係なく高さが揃うようにしました。
さらに、本文（.post-content）には-webkit-line-clampを用いて3行までの表示に制限し、溢れた文章を省略記号「…」で表示するように実装。
一文のみの場合も上部に自然に揃うよう、.post-card-bodyのflex指定を解除し、通常のブロック要素として扱うことで、行数に依存しない自然なテキスト位置を実現しました。
これにより、投稿カード全体の高さが統一され、読みやすく整った一覧表示が完成しています。