### PR TITLE
X共有実装、new、editのコメント、公開設定の順序入れ替え

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -5,23 +5,3 @@ import "./posts/post_form";
 import "./posts/post_edit";
 import "./posts/placeholder_switch";
 import "./posts/flowers";
-
-// Turbo ログ確認
-["turbo:load", "turbo:render"].forEach((event) => {
-  document.addEventListener(event, () => {
-    const cssLoaded = Array.from(document.styleSheets).some((s) =>
-      s.href?.includes("application")
-    );
-    const hasCustom = Array.from(document.styleSheets).some((s) => {
-      try {
-        return Array.from(s.cssRules || []).some((r) =>
-          r.selectorText?.includes(".wooden-header")
-        );
-      } catch {
-        return false;
-      }
-    });
-
-    console.log(`⚡ ${event}: css=${cssLoaded}, custom=${hasCustom}`);
-  });
-});

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,8 +1,10 @@
 import { Application } from "@hotwired/stimulus";
 import SeasonController from "./season_controller";
 import CalendarTooltipController from "./calendar_tooltip_controller";
+import ShareController from "./share_controller"; 
 
 const application = Application.start();
 
 application.register("season", SeasonController);
 application.register("calendar-tooltip", CalendarTooltipController);
+application.register("share", ShareController);

--- a/app/javascript/controllers/share_controller.js
+++ b/app/javascript/controllers/share_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  share(event) {
+    event.preventDefault();
+
+    const text = "cocoposで心を投函しました📮\n#cocopos\n#心の目安箱\n";
+    const url = window.location.origin + "/";
+    const shareUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(
+      text + url
+    )}`;
+
+    window.open(shareUrl, "_blank", "noopener,noreferrer");
+
+    window.location.href = "/mypage";
+  }
+}

--- a/app/javascript/posts/placeholder_switch.js
+++ b/app/javascript/posts/placeholder_switch.js
@@ -1,4 +1,3 @@
-// app/javascript/posts/placeholder_switch.js
 document.addEventListener("turbo:load", () => {
   console.log("✏️ placeholder_switch loaded");
 
@@ -30,4 +29,11 @@ document.addEventListener("turbo:load", () => {
       postBody.placeholder = placeholders[type]?.body || "";
     });
   });
+
+  const checkedRadio = document.querySelector(".post-type-radio:checked");
+  if (checkedRadio) {
+    const type = checkedRadio.value;
+    postTitle.placeholder = placeholders[type]?.title || "";
+    postBody.placeholder = placeholders[type]?.body || "";
+  }
 });

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,17 +1,14 @@
 <main class="flex-grow pt-24 pb-12">
   <div class="container mx-auto max-w-4xl px-6">
 
-    <!-- ページタイトル -->
     <div class="text-center mb-8">
       <h1 class="text-4xl font-bold text-gray-800 mb-2">✏️ 投稿を編集</h1>
       <p class="text-gray-600">投稿内容を修正できます</p>
     </div>
 
-    <!-- 編集フォーム -->
     <div class="bg-white rounded-3xl shadow-lg p-8">
       <%= form_with model: @post, local: true do |f| %>
 
-        <!-- 📮 投稿タイプ選択 -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">📮 投函する箱を選んでください</label>
           <div class="grid md:grid-cols-3 gap-4">
@@ -33,33 +30,6 @@
           </div>
         </div>
 
-        <!-- 🔒 公開設定 -->
-        <div class="mb-8 relative z-10">
-          <label class="block text-lg font-bold text-gray-800 mb-4">🔒 公開設定</label>
-          <div class="flex gap-4">
-            <label class="flex-1 relative cursor-pointer select-none">
-              <%= f.radio_button :is_public, "true",
-                    class: "absolute inset-0 opacity-0 cursor-pointer peer",
-                    checked: @post.is_public? %>
-              <div class="card-ui p-4 border-2 border-gray-200 rounded-xl text-center transition-all bg-white hover:bg-orange-50">
-                🌐<br><strong>みんなに公開</strong>
-                <p class="text-sm text-gray-600 mt-1">投稿一覧に表示されます</p>
-              </div>
-            </label>
-
-            <label class="flex-1 relative cursor-pointer select-none">
-              <%= f.radio_button :is_public, "false",
-                    class: "absolute inset-0 opacity-0 cursor-pointer peer",
-                    checked: !@post.is_public? %>
-              <div class="card-ui p-4 border-2 border-gray-200 rounded-xl text-center transition-all bg-white hover:bg-orange-50">
-                🔒<br><strong>非公開にする</strong>
-                <p class="text-sm text-gray-600 mt-1">自分だけが見られます</p>
-              </div>
-            </label>
-          </div>
-        </div>
-
-        <!-- 💬 コメント設定 -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">💬 コメント設定</label>
           <div class="flex gap-4">
@@ -85,7 +55,31 @@
           </div>
         </div>
 
-        <!-- 🖋 タイトル -->
+        <div class="mb-8 relative z-10">
+          <label class="block text-lg font-bold text-gray-800 mb-4">🔒 公開設定</label>
+          <div class="flex gap-4">
+            <label class="flex-1 relative cursor-pointer select-none">
+              <%= f.radio_button :is_public, "true",
+                    class: "absolute inset-0 opacity-0 cursor-pointer peer",
+                    checked: @post.is_public? %>
+              <div class="card-ui p-4 border-2 border-gray-200 rounded-xl text-center transition-all bg-white hover:bg-orange-50">
+                🌐<br><strong>みんなに公開</strong>
+                <p class="text-sm text-gray-600 mt-1">投稿一覧に表示されます</p>
+              </div>
+            </label>
+
+            <label class="flex-1 relative cursor-pointer select-none">
+              <%= f.radio_button :is_public, "false",
+                    class: "absolute inset-0 opacity-0 cursor-pointer peer",
+                    checked: !@post.is_public? %>
+              <div class="card-ui p-4 border-2 border-gray-200 rounded-xl text-center transition-all bg-white hover:bg-orange-50">
+                🔒<br><strong>非公開にする</strong>
+                <p class="text-sm text-gray-600 mt-1">自分だけが見られます</p>
+              </div>
+            </label>
+          </div>
+        </div>
+
         <div class="mb-8">
           <label class="block text-lg font-bold text-gray-800 mb-4">🖋 タイトル</label>
           <%= f.text_field :title,
@@ -95,7 +89,6 @@
           <p class="text-right text-sm text-gray-500 mt-2">100文字以内</p>
         </div>
 
-        <!-- 📝 本文 -->
         <div class="mb-8">
           <label class="block text-lg font-bold text-gray-800 mb-4">📝 本文</label>
           <%= f.text_area :body,
@@ -108,7 +101,6 @@
           </div>
         </div>
 
-        <!-- 匿名設定 -->
         <div class="mb-8">
           <label class="flex items-center gap-3 cursor-pointer p-4 bg-gray-50 rounded-xl hover:bg-gray-100 transition">
             <%= f.check_box :is_anonymous, class: "w-5 h-5 text-orange-400 rounded focus:ring-orange-400" %>
@@ -119,7 +111,6 @@
           </label>
         </div>
 
-        <!-- エラーメッセージ -->
         <% if @post.errors.any? %>
           <div class="mb-8 p-4 bg-red-50 border-l-4 border-red-500 rounded">
             <h3 class="font-bold text-red-700 mb-2">エラーが発生しました</h3>
@@ -131,7 +122,6 @@
           </div>
         <% end %>
 
-        <!-- ボタン -->
         <div class="flex justify-center gap-4">
           <%= f.submit "更新する", class: "px-12 py-3 bg-gradient-to-r from-blue-400 to-blue-500 text-white text-lg font-bold rounded-full hover:shadow-xl transition transform hover:scale-105 cursor-pointer" %>
           <%= link_to "キャンセル", @post, class: "px-8 py-3 bg-gray-200 text-gray-700 font-bold rounded-full hover:bg-gray-300 transition" %>
@@ -140,7 +130,6 @@
       <% end %>
     </div>
 
-    <!-- 削除ボタン -->
     <div class="mt-8 text-center">
       <%= button_to "この投稿を削除する", @post,
           method: :delete,
@@ -152,7 +141,6 @@
 </main>
 
 <script>
-  // 文字数カウント
   document.addEventListener('turbo:load', () => {
     const textarea = document.querySelector('textarea[name="post[body]"]');
     const charCount = document.getElementById('charCount');

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -61,7 +61,6 @@
 
           <div class="post-card-footer flex justify-between items-center text-sm text-gray-600 px-6 py-4 bg-gray-50 border-t">
 
-            <!-- 左側：投稿者・非公開・コメント不要 -->
             <div class="flex items-center gap-2 flex-wrap">
               <span class="post-author"><%= post.display_name %></span>
 
@@ -69,25 +68,23 @@
                 <span class="inline-block px-2 py-1 bg-gray-200 text-gray-700 rounded-full text-xs">非公開</span>
               <% end %>
 
-              <% unless post.opinion_needed? %>
+              <% if post.opinion_needed? %>
+                <span class="inline-block px-2 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-bold">💬 意見募集中</span>
+              <% else %>
                 <span class="inline-block px-2 py-1 bg-gray-200 text-gray-700 rounded-full text-xs">💭 コメント不要</span>
               <% end %>
             </div>
 
-            <!-- 右側：花ボタン + コメントボタン -->
             <% if post.is_public? %>
               <div class="post-actions flex items-center gap-3">
-
-                <!-- 🌸 花ボタン（Turbo対象） -->
                 <div id="flower_btn_post_<%= post.id %>">
                   <%= render "flowers/button", flowerable: post %>
                 </div>
 
-                <!-- 💬 コメントボタン -->
                 <% if post.opinion_needed? %>
                   <%= link_to post_path(post, anchor: "comment-form"),
                               data: { turbo: false },
-                              class: "action-icon comment-btn" do %>
+                              class: "action-icon comment-btn flex items-center gap-1" do %>
                     💬 <span><%= post.comments.count %></span>
                   <% end %>
                 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,12 +1,11 @@
 <main class="flex-grow pt-24 pb-12">
   <div class="container mx-auto max-w-4xl px-6">
-    <!-- ページタイトル -->
+
     <div class="text-center mb-8">
       <h1 class="text-4xl font-bold text-gray-800 mb-2">✏️ 新しい投稿</h1>
       <p class="text-gray-600">あなたの心を投函してください</p>
     </div>
 
-    <!-- 投稿フォーム -->
     <div class="bg-white rounded-3xl shadow-lg p-8">
       <%= form_with model: @post,
               id: "postForm",
@@ -14,7 +13,6 @@
               data: { turbo: false },
               html: { onsubmit: "return false;" } do |f| %>
 
-        <!-- 1) 📮 投稿タイプ選択 -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">📮 投函する箱を選んでください</label>
           <div class="grid md:grid-cols-3 gap-4">
@@ -23,7 +21,7 @@
                  thanks: ["💌", "感謝箱", "感謝の気持ちを記録"] }.each do |type, (icon, title, desc)| %>
               <label class="relative cursor-pointer select-none">
                 <%= f.radio_button :post_type, type,
-                      class: "absolute inset-0 opacity-0 cursor-pointer peer z-20",
+                      class: "absolute inset-0 opacity-0 cursor-pointer peer z-20 post-type-radio",
                       required: true %>
                 <div class="card-ui text-center border-2 border-gray-200 rounded-xl p-4 transition-all
                             peer-checked:border-orange-400 peer-checked:ring-2 peer-checked:ring-orange-200
@@ -37,7 +35,34 @@
           </div>
         </div>
 
-        <!-- 2) 🔒 公開設定 -->
+        <div class="mb-8 relative z-10">
+          <label class="block text-lg font-bold text-gray-800 mb-4">💬 コメント設定</label>
+          <div class="flex gap-4">
+            <label class="flex-1 relative cursor-pointer select-none z-10">
+              <%= f.radio_button :comment_allowed, "true",
+                    checked: true,
+                    class: "absolute inset-0 opacity-0 cursor-pointer peer z-20" %>
+              <div class="card-ui p-4 border-2 border-gray-200 rounded-xl text-center transition-all
+                          peer-checked:border-orange-400 peer-checked:ring-2 peer-checked:ring-orange-200
+                          bg-white hover:bg-orange-50">
+                💬<br><strong>コメントを許可する</strong>
+                <p class="text-sm text-gray-600 mt-1">他の人が感想や励ましを書けます</p>
+              </div>
+            </label>
+
+            <label class="flex-1 relative cursor-pointer select-none z-10">
+              <%= f.radio_button :comment_allowed, "false",
+                    class: "absolute inset-0 opacity-0 cursor-pointer peer z-20" %>
+              <div class="card-ui p-4 border-2 border-gray-200 rounded-xl text-center transition-all
+                          peer-checked:border-orange-400 peer-checked:ring-2 peer-checked:ring-orange-200
+                          bg-white hover:bg-orange-50">
+                🚫<br><strong>コメント不要</strong>
+                <p class="text-sm text-gray-600 mt-1">静かに残したい投稿に</p>
+              </div>
+            </label>
+          </div>
+        </div>
+
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">🔒 公開設定</label>
           <div class="flex gap-4">
@@ -66,54 +91,22 @@
           </div>
         </div>
 
-        <!-- 3) 💬 コメント設定 -->
-        <div class="mb-8 relative z-10">
-          <label class="block text-lg font-bold text-gray-800 mb-4">💬 コメント設定</label>
-          <div class="flex gap-4">
-            <!-- コメント許可 -->
-            <label class="flex-1 relative cursor-pointer select-none z-10">
-              <%= f.radio_button :comment_allowed, "true",
-                    checked: true,
-                    class: "absolute inset-0 opacity-0 cursor-pointer peer z-20" %>
-              <div class="card-ui p-4 border-2 border-gray-200 rounded-xl text-center transition-all
-                          peer-checked:border-orange-400 peer-checked:ring-2 peer-checked:ring-orange-200
-                          bg-white hover:bg-orange-50">
-                💬<br><strong>コメントを許可する</strong>
-                <p class="text-sm text-gray-600 mt-1">他の人が感想や励ましを書けます</p>
-              </div>
-            </label>
-
-            <!-- コメント不要 -->
-            <label class="flex-1 relative cursor-pointer select-none z-10">
-              <%= f.radio_button :comment_allowed, "false",
-                    class: "absolute inset-0 opacity-0 cursor-pointer peer z-20" %>
-              <div class="card-ui p-4 border-2 border-gray-200 rounded-xl text-center transition-all
-                          peer-checked:border-orange-400 peer-checked:ring-2 peer-checked:ring-orange-200
-                          bg-white hover:bg-orange-50">
-                🚫<br><strong>コメント不要</strong>
-                <p class="text-sm text-gray-600 mt-1">静かに残したい投稿に</p>
-              </div>
-            </label>
-          </div>
-        </div>
-
-        <!-- 4) 🖋 タイトル -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">🖋 タイトル</label>
           <%= f.text_field :title,
+              id: "post_title",
               class: "w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-orange-400 focus:outline-none",
               maxlength: 100,
               required: true %>
           <p class="text-right text-sm text-gray-500 mt-2">100文字以内</p>
         </div>
 
-        <!-- 5) 📝 本文 -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">📝 本文</label>
           <%= f.text_area :body,
               rows: 8,
-              class: "w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-orange-400 focus:outline-none resize-none",
               id: "post_body",
+              class: "w-full px-4 py-3 border-2 border-gray-200 rounded-xl focus:border-orange-400 focus:outline-none resize-none",
               maxlength: 1000,
               required: true %>
           <p class="text-right text-sm text-gray-500 mt-2">
@@ -121,7 +114,6 @@
           </p>
         </div>
 
-        <!-- 6) 👤 匿名設定 -->
         <div class="mb-8">
           <label class="flex items-center gap-3 cursor-pointer p-4 bg-gray-50 rounded-xl hover:bg-gray-100 transition">
             <%= f.check_box :is_anonymous, class: "w-5 h-5 text-orange-400 rounded focus:ring-orange-400" %>
@@ -132,7 +124,6 @@
           </label>
         </div>
 
-        <!-- 7) ボタン -->
         <div class="flex justify-center gap-4 relative z-10">
           <%= f.submit "投函する 📮",
                 class: "px-12 py-3 bg-gradient-to-r from-orange-400 to-pink-400 text-white text-lg font-bold rounded-full hover:shadow-xl transition transform hover:scale-105" %>
@@ -143,7 +134,6 @@
   </div>
 </main>
 
-<!-- === ローディング画面 === -->
 <div id="loadingScreen" class="loading-screen">
   <div class="postbox-animation">
     <div class="letter"></div>
@@ -152,7 +142,6 @@
   </div>
 </div>
 
-<!-- === 完了画面 === -->
 <div id="completionScreen" class="completion-screen">
   <div class="completion-content">
     <div class="checkmark"></div>
@@ -171,7 +160,7 @@
         <div class="action-icon">👤</div>
         <h3 class="text-lg font-bold mb-1 text-gray-800">マイページを見る</h3>
       <% end %>
-      <a href="#" class="action-card" onclick="shareOnX(event)">
+      <a href="#" data-controller="share" data-action="click->share#share" class="action-card">
         <div class="action-icon">🐦</div>
         <h3 class="text-lg font-bold mb-1 text-gray-800">Xで共有する</h3>
       </a>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,17 +1,14 @@
 <main class="flex-grow pt-24 pb-12">
   <div class="container mx-auto max-w-4xl px-6">
 
-    <!-- 戻るボタン -->
     <div class="mb-6">
       <%= link_to "← 投稿一覧に戻る",
                   posts_path,
                   class: "text-gray-600 hover:text-gray-800 transition" %>
     </div>
 
-    <!-- 投稿カード -->
     <div class="post-detail-card bg-white rounded-3xl shadow-lg overflow-hidden">
 
-      <!-- ヘッダー -->
       <div class="post-header p-6 border-b <%= @post.post_type_color %>">
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-3">
@@ -40,29 +37,27 @@
           <% end %>
         </div>
 
-        <% if @post.organize? %>
+        <% if @post.opinion_needed? %>
           <div class="mt-4">
-            <% if @post.opinion_needed %>
-              <span class="inline-block px-4 py-2 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
-                💬 意見募集中
-              </span>
-            <% else %>
-              <span class="inline-block px-4 py-2 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
-                💭 意見不要
-              </span>
-            <% end %>
+            <span class="inline-block px-4 py-2 bg-blue-100 text-blue-700 rounded-full text-sm font-bold">
+              💬 意見募集中
+            </span>
+          </div>
+        <% else %>
+          <div class="mt-4">
+            <span class="inline-block px-4 py-2 bg-gray-100 text-gray-700 rounded-full text-sm font-bold">
+              💭 意見不要
+            </span>
           </div>
         <% end %>
       </div>
 
-      <!-- 本文 -->
       <div class="post-body p-8">
         <div class="prose max-w-none">
           <p class="text-lg text-gray-800 leading-relaxed whitespace-pre-wrap"><%= @post.body %></p>
         </div>
       </div>
 
-      <!-- フッター -->
       <div class="post-footer p-6 bg-gray-50 border-t rounded-b-3xl">
         <div class="flex items-center justify-between">
           <div class="flex items-center gap-4">
@@ -72,7 +67,6 @@
             </span>
           </div>
 
-          <!-- 🌱 投稿用 花ボタン -->
           <div id="flower_btn_post_<%= @post.id %>">
             <%= render "flowers/button", flowerable: @post %>
           </div>
@@ -80,30 +74,40 @@
       </div>
     </div>
 
-    <!-- 💬 コメントエリア -->
     <div class="mt-12 space-y-10">
 
-      <!-- コメントフォーム -->
       <section id="comment-form" class="comment-form">
         <h3 class="form-title text-lg font-bold mb-4">📝 コメントを書く</h3>
 
         <% if user_signed_in? %>
           <%= form_with(model: [@post, Comment.new], local: true) do |f| %>
-            <%= f.text_area :content,
-                            rows: 3,
-                            placeholder: "心に浮かんだ言葉をどうぞ…",
-                            class: "w-full border border-gray-300 rounded-xl p-3 mb-4 focus:outline-none focus:ring-2 focus:ring-green-300 text-sm bg-white" %>
+            <% if @post.is_public? %>
+              <%= f.text_area :content,
+                              rows: 3,
+                              placeholder: "心に浮かんだ言葉をどうぞ…",
+                              class: "w-full border border-gray-300 rounded-xl p-3 mb-4 focus:outline-none focus:ring-2 focus:ring-green-300 text-sm bg-white" %>
 
-            <div class="flex items-center justify-between mt-3">
-              <label class="flex items-center gap-2 text-sm text-gray-700">
-                <%= f.check_box :is_anonymous,
-                                class: "h-4 w-4 text-green-500 rounded border-gray-300 focus:ring-green-400" %>
-                匿名で投稿する
-              </label>
+              <div class="flex items-center justify-between mt-3">
+                <label class="flex items-center gap-2 text-sm text-gray-700">
+                  <%= f.check_box :is_anonymous,
+                                  class: "h-4 w-4 text-green-500 rounded border-gray-300 focus:ring-green-400" %>
+                  匿名で投稿する
+                </label>
 
-              <%= f.submit "投稿する",
-                          class: "bg-green-500 text-white px-6 py-2 text-sm rounded-xl hover:bg-green-600 transition shadow-sm" %>
-            </div>
+                <%= f.submit "投稿する",
+                            class: "bg-green-500 text-white px-6 py-2 text-sm rounded-xl hover:bg-green-600 transition shadow-sm" %>
+              </div>
+            <% else %>
+              <%= f.text_area :content,
+                              rows: 3,
+                              disabled: true,
+                              placeholder: "非公開投稿のためコメントは追加できません。",
+                              class: "w-full border border-gray-300 rounded-xl p-3 mb-4 text-gray-400 bg-gray-100 cursor-not-allowed" %>
+
+              <div class="text-sm text-gray-500 text-right italic">
+                💬 既存のコメントのみ閲覧できます
+              </div>
+            <% end %>
           <% end %>
         <% else %>
           <p class="login-required text-center text-gray-500 py-4">
@@ -112,7 +116,6 @@
         <% end %>
       </section>
 
-      <!-- コメント一覧 -->
       <section class="comments-section rounded-3xl shadow-md border border-gray-100 p-6">
         <h3 class="section-title text-lg font-semibold text-gray-800 mb-6">
           💬 <span>みんなのコメント</span>

--- a/app/views/users/mypage_posts.html.erb
+++ b/app/views/users/mypage_posts.html.erb
@@ -65,12 +65,14 @@
 
           <div class="post-card-footer flex justify-between items-center text-sm text-gray-600 px-6 py-4 bg-gray-50 border-t">
             <div class="flex items-center gap-2 flex-wrap">
-              <% unless post.is_public %>
+              <% if !post.is_public %>
                 <span class="inline-block px-2 py-1 bg-gray-200 text-gray-700 rounded-full text-xs">非公開</span>
-              <% end %>
-
-              <% unless post.opinion_needed? %>
-                <span class="inline-block px-2 py-1 bg-gray-200 text-gray-700 rounded-full text-xs">💭 コメント不要</span>
+              <% else %>
+                <% if post.opinion_needed? %>
+                  <span class="inline-block px-2 py-1 bg-blue-100 text-blue-700 rounded-full text-xs font-bold">💬 意見募集中</span>
+                <% else %>
+                  <span class="inline-block px-2 py-1 bg-gray-200 text-gray-700 rounded-full text-xs">💭 コメント不要</span>
+                <% end %>
               <% end %>
             </div>
 
@@ -79,10 +81,10 @@
                 <%= render "flowers/button", flowerable: post %>
               </div>
 
-              <% if post.opinion_needed? %>
+              <% if post.is_public? && post.opinion_needed? %>
                 <%= link_to post_path(post, anchor: "comment-form"),
                             data: { turbo: false },
-                            class: "action-icon comment-btn" do %>
+                            class: "action-icon comment-btn flex items-center gap-1" do %>
                   💬 <span><%= post.comments.count %></span>
                 <% end %>
               <% end %>
@@ -106,3 +108,4 @@
 
   </div>
 </main>
+


### PR DESCRIPTION
本実装では、投稿をX（旧Twitter）で共有できる機能を追加しました。
投稿完了後に「cocoposで心を投函しました📮」という文面とハッシュタグ「#cocopos」「#心の目安箱」を含むツイート画面を自動で開き、リンク先をトップページ（/）に設定しています。ユーザーはシェア後、自動的にマイページへ遷移する流れになっています。

また、投稿フォーム画面の構成を見直しました。
これまで上部にあった「公開・非公開設定」を下部に移動し、入力内容（箱の選択、本文、コメントの有無）をすべて確認した後で公開設定を選べるようにしています。これにより、誤って設定を切り替えるミスを防ぎ、操作の流れが自然になりました。

さらに、新規投稿（new）と編集（edit）ページのコメント欄や説明文の順序も整理しました。