### PR TITLE
投稿一覧に検索フォーム追加

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -8,6 +8,13 @@ class PostsController < ApplicationController
     @posts = Post.includes(:user, comments: :user, flowers: :user)
     @posts = filter_by_visibility(@posts)
     @posts = filter_by_type(@posts)
+
+
+    if params[:q].present?
+      query = "%#{params[:q]}%"
+      @posts = @posts.where("title ILIKE :q OR body ILIKE :q", q: query)
+    end
+
     @posts = sort_posts(@posts)
     @posts = paginate_posts(@posts)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -24,6 +24,12 @@ class UsersController < ApplicationController
   def filtered_posts
     posts = current_user.posts
     posts = filter_posts(posts)
+
+    if params[:q].present?
+      query = "%#{params[:q]}%"
+      posts = posts.where("title ILIKE :q OR body ILIKE :q", q: query)
+    end
+
     sort_posts(posts)
   end
 

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,0 +1,10 @@
+<div class="flex justify-end mb-6">
+  <%= form_with url: posts_path, method: :get, local: true, class: "flex gap-2 items-center" do |f| %>
+    <%= f.text_field :q, value: params[:q], placeholder: "検索",
+        class: "border rounded px-2 py-1 text-sm w-40" %>
+    <%= f.hidden_field :filter, value: params[:filter] %>
+    <%= f.hidden_field :sort, value: params[:sort] %>
+    <%= f.submit "🔍", class: "bg-blue-500 text-white px-2 py-1 rounded text-sm" %>
+  <% end %>
+</div>
+

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,6 +6,8 @@
       <p class="text-gray-600">心の目安箱に投函された想い</p>
     </div>
 
+    <%= render "search_form" %>
+
     <div class="filter-bar flex flex-col md:flex-row md:items-center md:justify-between mb-8 gap-4">
       <div class="filter-buttons flex flex-wrap items-center gap-2">
         <span class="filter-label font-semibold text-gray-700">絞り込み：</span>
@@ -30,7 +32,7 @@
       <%= form_with url: posts_path, method: :get, local: true, class: "filter-right" do |f| %>
         <%= f.hidden_field :filter, value: params[:filter] %>
         <select name="sort" onchange="this.form.submit()" class="sort-select border-gray-300 rounded-lg px-3 py-1">
-          <option value="new" <%= 'selected' if params[:sort] != 'old' %>>新着順</option>
+          <option value="new" <%= 'selected' if params[:sort] != 'old' %>>新しい順</option>
           <option value="old" <%= 'selected' if params[:sort] == 'old' %>>古い順</option>
         </select>
       <% end %>
@@ -39,7 +41,6 @@
     <div class="posts-grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
       <% @posts.each do |post| %>
         <div class="post-card bg-white rounded-3xl shadow-lg overflow-hidden hover:shadow-xl transition">
-
 
           <%= link_to post_path(post, from: 'public'),
                       data: { turbo: false, id: post.id, category: post.post_type },

--- a/app/views/users/mypage_posts.html.erb
+++ b/app/views/users/mypage_posts.html.erb
@@ -6,6 +6,9 @@
       <p class="text-gray-600">これまで投函した想いを振り返りましょう</p>
     </div>
 
+    <%= render "posts/search_form" %>
+
+
     <div class="filter-bar flex flex-col md:flex-row md:items-center md:justify-between mb-8 gap-4">
       <div class="filter-buttons flex flex-wrap items-center gap-2">
         <span class="filter-label font-semibold text-gray-700">箱の種類：</span>


### PR DESCRIPTION
この実装では、「みんなの投稿一覧」と「あなたの投稿一覧」の両ページで共通の投稿表示フォーマットを利用する設計が中心です。ページ上部にタイトルや説明文を配置した後、検索フォームや絞り込み機能は部分テンプレート _search_form.html.erb を読み込む形で共通化しています。投稿カードの構造も共通化されており、タイトル、本文抜粋、投稿タイプアイコン、作成日時、非公開・コメント可否のラベル、花アイコンやコメント数などのアクションを統一して表示しています。これにより、両ページのUIや操作性を一貫させつつ、部分テンプレートの再利用によって保守性と拡張性を高めています。