### PR TITLE
NGワードフィルタリング、管理者による投稿削除可能機能追加

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,50 +6,65 @@ class CommentsController < ApplicationController
   before_action :set_comment, only: %i[edit update destroy]
   before_action :authorize_user!, only: %i[edit update destroy]
 
+  # コメント作成
   def create
     @comment = @post.comments.build(comment_params)
     @comment.user = current_user
 
     if @comment.save
-      redirect_to post_path(@post), notice: 'コメントを投稿しました。'
+      redirect_to post_path(@post), notice: t('comments.notices.created')
     else
-      redirect_to post_path(@post), alert: 'コメントの投稿に失敗しました。'
+      redirect_to post_path(@post), alert: t('comments.alerts.failed')
     end
   end
 
-
+  # コメント編集フォーム
   def edit; end
 
-
+  # コメント更新
   def update
     if @comment.update(comment_params)
-      redirect_to post_path(@post), notice: 'コメントを更新しました。'
+      redirect_to post_path(@post), notice: t('comments.notices.updated')
     else
       render :edit, status: :unprocessable_entity
     end
   end
 
-
+  # コメント削除
   def destroy
     @comment.destroy
-    redirect_to post_path(@post), notice: 'コメントを削除しました。'
+    redirect_to post_path(@post), notice: t('comments.notices.deleted')
   end
 
   private
 
+  # 投稿セット
   def set_post
     @post = Post.find(params[:post_id])
   end
 
+  # コメントセット
   def set_comment
     @comment = @post.comments.find(params[:id])
   end
 
+  # 編集・削除権限確認
   def authorize_user!
-    redirect_to post_path(@post), alert: '編集権限がありません。' unless @comment.user == current_user
+    # 管理者は update（編集）にはアクセス不可、destroy（削除）はOK
+    if current_user.admin? && action_name == 'destroy'
+      return
+    end
+
+    # 投稿者は編集・削除ともにアクセス可能
+    return if @comment.user == current_user
+
+    # それ以外は権限なし
+    redirect_to post_path(@post), alert: t('comments.alerts.unauthorized')
   end
 
+  # Strong Parameters
   def comment_params
     params.require(:comment).permit(:content, :is_anonymous)
   end
 end
+

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,11 +4,11 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[show edit update destroy]
   before_action :authorize_user!, only: %i[edit update destroy]
 
+  # 投稿一覧
   def index
     @posts = Post.includes(:user, comments: :user, flowers: :user)
     @posts = filter_by_visibility(@posts)
     @posts = filter_by_type(@posts)
-
 
     if params[:q].present?
       query = "%#{params[:q]}%"
@@ -19,15 +19,18 @@ class PostsController < ApplicationController
     @posts = paginate_posts(@posts)
   end
 
+  # 投稿詳細
   def show
     redirect_to posts_path, alert: t('posts.alerts.private') and return if private_post_blocked?
     @comments = @post.comments.includes(:user, :flowers)
   end
 
+  # 新規投稿フォーム
   def new
     @post = Post.new
   end
 
+  # 投稿作成
   def create
     @post = current_user.posts.build(post_params)
     disable_comment_if_private(@post)
@@ -41,8 +44,10 @@ class PostsController < ApplicationController
     end
   end
 
+  # 投稿編集フォーム
   def edit; end
 
+  # 投稿更新
   def update
     updated_params = prepare_updated_params(@post, post_params)
 
@@ -54,6 +59,7 @@ class PostsController < ApplicationController
     end
   end
 
+  # 投稿削除
   def destroy
     @post.destroy
     redirect_after_action(nil, t('posts.notices.deleted'))
@@ -61,6 +67,7 @@ class PostsController < ApplicationController
 
   private
 
+  # リダイレクト処理
   def redirect_after_action(post, message)
     if params[:from] == 'mypage'
       redirect_to mypage_posts_path, notice: message
@@ -71,23 +78,29 @@ class PostsController < ApplicationController
     end
   end
 
+  # 投稿セット
   def set_post
     @post = Post.includes(:user, comments: :user, flowers: :user).find(params[:id])
   end
 
+  # 投稿編集・削除権限確認
   def authorize_user!
-    redirect_to posts_path, alert: t('posts.alerts.unauthorized') unless @post.user == current_user
+    redirect_to posts_path, alert: t('posts.alerts.unauthorized') unless @post.user == current_user || current_user.admin?
   end
 
+
+  # 公開状態によるフィルタ
   def filter_by_visibility(posts)
     posts.where(is_public: true)
   end
 
+  # 投稿タイプによるフィルタ
   def filter_by_type(posts)
     return posts if params[:filter].blank? || params[:filter] == 'all'
     posts.where(post_type: params[:filter])
   end
 
+  # 並び替え
   def sort_posts(posts)
     case params[:sort]
     when 'old'
@@ -97,23 +110,28 @@ class PostsController < ApplicationController
     end
   end
 
+  # ページネーション
   def paginate_posts(posts)
     posts.page(params[:page]).per(10)
   end
 
+  # 非公開投稿閲覧制御
   def private_post_blocked?
     !@post.is_public && (!user_signed_in? || @post.user != current_user)
   end
 
+  # 非公開投稿はコメント不可
   def disable_comment_if_private(post)
     post.comment_allowed = false unless post.is_public
   end
 
+  # 成功レスポンス
   def success_response(format, post)
     format.html { redirect_to post_path(post, from: params[:from]), notice: t('posts.notices.created') }
     format.json { render json: { success: true }, status: :created }
   end
 
+  # 失敗レスポンス
   def failure_response(format, post)
     format.html { render :new, status: :unprocessable_entity }
     format.json do
@@ -121,6 +139,7 @@ class PostsController < ApplicationController
     end
   end
 
+  # 更新用パラメータ整形
   def prepare_updated_params(post, params)
     updated = params.dup
     updated[:is_public] = fetch_bool(updated, :is_public, post.is_public)
@@ -135,11 +154,13 @@ class PostsController < ApplicationController
     updated
   end
 
+  # 真偽値キャスト
   def fetch_bool(hash, key, fallback)
     return fallback unless hash.key?(key)
     ActiveModel::Type::Boolean.new.cast(hash[key])
   end
 
+  # Strong Parameters
   def post_params
     permitted = params.require(:post).permit(
       :title,
@@ -152,6 +173,7 @@ class PostsController < ApplicationController
     cast_booleans(permitted, %i[is_public comment_allowed])
   end
 
+  # パラメータ内の真偽値をキャスト
   def cast_booleans(permitted, keys)
     bool = ActiveModel::Type::Boolean.new
     keys.each do |key|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,12 @@ class User < ApplicationRecord
   # バリデーション
   validates :name, presence: true, length: { maximum: 50 }
 
+  # 管理者フラグ
+  # migrationで追加: add_column :users, :admin, :boolean, default: false, null: false
+  def admin?
+    self.admin
+  end
+
   # 表示名（匿名対応）
   def display_name
     name.presence || '匿名ユーザー'

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,19 +1,24 @@
-<div class="comment-card">
-  <p class="comment-content"><%= comment.content %></p>
+<div class="comment-card bg-white rounded-xl shadow-sm p-4">
+  <p class="comment-content text-gray-800 leading-relaxed"><%= comment.content %></p>
 
-  <p class="comment-meta">
-    by
-    <%= comment.is_anonymous ? "匿名さん" : (comment.user.display_name || "匿名ユーザー") %>
-    ・ <%= comment.created_at.strftime("%Y/%m/%d %H:%M") %>
+  <p class="comment-meta text-gray-500 text-sm mt-2">
+    <span><%= t('comments.labels.by', default: 'by') %></span>
+    <span>
+      <%= comment.is_anonymous ? t('comments.labels.anonymous', default: '匿名さん') : (comment.user.display_name || t('comments.labels.anonymous_user', default: '匿名ユーザー')) %>
+    </span>
+    ・ <span><%= l comment.created_at, format: :short %></span>
   </p>
 
   <div class="flex items-center justify-between mt-3">
-    <% if comment.user == current_user %>
+    <% if comment.user == current_user || current_user.admin? %>
       <div class="comment-actions flex gap-2">
-        <%= link_to "編集", edit_post_comment_path(@post, comment), class: "edit-btn text-sm text-blue-600 hover:underline" %>
-        <%= button_to "削除", post_comment_path(@post, comment),
+        <% if comment.user == current_user %>
+          <%= link_to t('comments.buttons.edit', default: '編集'), edit_post_comment_path(@post, comment), class: "edit-btn text-sm text-blue-600 hover:underline" %>
+        <% end %>
+
+        <%= button_to t('comments.buttons.delete', default: '削除'), post_comment_path(@post, comment),
                       method: :delete,
-                      data: { turbo_confirm: "削除しますか？" },
+                      data: { turbo_confirm: t('comments.buttons.confirm_delete', default: '本当に削除しますか？この操作は取り消せません。') },
                       class: "delete-btn text-sm text-red-500 hover:underline" %>
       </div>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -22,11 +22,13 @@
             </div>
           </div>
 
-          <% if user_signed_in? && @post.user == current_user %>
+          <% if user_signed_in? && (@post.user == current_user || current_user.admin?) %>
             <div class="flex gap-2">
-              <%= link_to edit_post_path(@post, from: params[:from]),
-                          class: "px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition" do %>
-                ✏️ 編集
+              <% if @post.user == current_user %>
+                <%= link_to edit_post_path(@post, from: params[:from]),
+                            class: "px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition" do %>
+                  ✏️ 編集
+                <% end %>
               <% end %>
 
               <%= button_to post_path(@post, from: params[:from]),
@@ -142,3 +144,4 @@
     </div>
   </div>
 </main>
+

--- a/config/initializers/ng_words.rb
+++ b/config/initializers/ng_words.rb
@@ -1,0 +1,21 @@
+# config/initializers/ng_words.rb
+
+NG_WORDS = %w[
+不適切 危険 卑猥 暴力 差別 嫌がらせ 下品 侮辱 中傷 暴言 罵倒 わいせつ 淫ら 露骨 乱暴 下ネタ 性的 嫌悪 悪口 罵声 嘲笑 強姦 殺害
+暴行 殴打 脅迫 犯罪 麻薬 薬物 性犯罪 違法 飲酒 喫煙 自傷 自殺 死 犯罪予告 暴力行為 差別用語 反社会的 ヘイト 過激 卑劣 嘘 虚偽 扇動
+過激表現 暴言中傷 迷惑行為 不快 嫌気 悪質 不愉快 危険行為 危険物 犯罪行為 卑猥表現 侮辱行為 卑劣行為 暴力表現 脅迫行為 性的表現 性的表現 下品表現 卑猥行為
+過激言動 暴力言動 脅迫言動 差別言動 侮辱言動 中傷言動 嫌がらせ言動 不適切言動 不快発言 不謹慎 不謹慎表現 性的嫌がらせ 性的暴力 性的差別 下品発言 下ネタ発言 卑猥発言
+過激表現発言 暴力発言 脅迫発言 差別発言 嘲笑発言 虐待 虐殺 暴動 テロ 違法薬物 犯罪組織 暴力団 麻薬取引 強盗 殺人 監禁 拉致 拷問
+暴言行為 嘘情報 デマ 偽情報 淫行 強制性交 ポルノ 色情 撲殺 誹謗 中傷 英語_swear fuck shit bitch asshole bastard slut dick pussy rape
+cock cum blowjob handjob masturbate hentai porn sex nude naked fucker cocksucker asshole motherfucker
+bitchy slutty whore horny hornyfuck fucked fucking kill death murder torture rape gangrape pedo pedophile childporn
+drugs cocaine heroin meth marijuana alcohol cigarettes smoking suicide selfharm bomb terror terrorist attack shooting
+killings behead decapitate violent beat abuse assault molest harass stalk fraud scam cheat ripoff
+insult insulted degrading humiliation humiliation act offensive vulgar disgusting disgustingness nasty nastyword
+racist sexist homophobic xenophobic hate slur profanity offensiveword inappropriate obscene indecent
+pervert perverted freak freaky creeper creep creepy gross nasty evil malicious nastyass evilass
+slutbag whorebag dirty whoremonger nigger chink jap spic kike fag dyke queer tranny trannyhate trannykill
+pedo childmolester kiddiefuck kiddieporn necro necrophilia bestiality zoophilia animalporn incest taboo
+voyeur voyeurism peeping tom spy hacker virus malware trojan phishing scam botnet exploit hackerattack
+cheater liar liarliar lying false falseinfo fake propaganda spam troll griefing annoying bother disturb
+]

--- a/config/locales/posts.ja.yml
+++ b/config/locales/posts.ja.yml
@@ -5,11 +5,23 @@ ja:
       updated: "投稿を更新しました。"
       deleted: "投稿を削除しました。" 
     alerts:
-      not_authorized: "権限がありません。"
+      unauthorized: "権限がありません。"
       private_post: "この投稿は非公開です。"
     buttons:
       new: "新規投稿"
       edit: "編集"
       delete: "削除"
       back: "戻る"
+      confirm_delete: "本当に削除しますか？この操作は取り消せません。"
+
+  comments:
+    notices:
+      created: "コメントを投稿しました。"
+      updated: "コメントを更新しました。"
+      deleted: "コメントを削除しました。"
+    alerts:
+      unauthorized: "権限がありません。"
+    buttons:
+      edit: "編集"
+      delete: "削除"
       confirm_delete: "本当に削除しますか？この操作は取り消せません。"

--- a/db/migrate/20251129082806_add_admin_to_users.rb
+++ b/db/migrate/20251129082806_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :admin, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_11_29_044239) do
+ActiveRecord::Schema[7.1].define(version: 2025_11_29_082806) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -39,6 +39,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_29_044239) do
   create_table "posts", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.text "body", null: false
+    t.boolean "opinion_needed", default: true
     t.boolean "is_anonymous", default: true
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -60,6 +61,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_11_29_044239) do
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
+    t.boolean "admin", default: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end


### PR DESCRIPTION
投稿・コメントに対して NG ワードのチェック機能を導入し、入力時に不適切な言葉を検出して保存前に除外または警告を行います。投稿者は自分の投稿・コメントを編集・削除できますが、管理者は投稿・コメントの編集は不可で削除のみ可能です。before_action で対象オブジェクトをセットし、authorize_user! メソッドで権限を判定。管理者の場合は削除アクションのみ通過させ、投稿者は編集・削除とも許可、それ以外はアクセス禁止とします。ビューでは、削除ボタンは管理者と投稿者に表示され、編集ボタンは投稿者のみ表示されます。