### PR TITLE
投稿後は箱の編集ができないように編集

### DIFF
--- a/app/javascript/posts/post_form.js
+++ b/app/javascript/posts/post_form.js
@@ -1,3 +1,4 @@
+// 投稿フォーム初期化
 const initPostForm = () => {
   const form = document.querySelector("#postForm");
   if (!form) return;
@@ -46,6 +47,7 @@ const initPostForm = () => {
       const result = await response.json();
 
       if (result.success) {
+        // 成功アニメーション
         if (letter) {
           letter.addEventListener(
             "animationend",
@@ -60,17 +62,31 @@ const initPostForm = () => {
           complete.classList.add("active");
         }
       } else {
+        // ❗ サーバーが返したエラー（NGワードなど）
+        loading.classList.remove("active");
+
+        if (result.errors && result.errors.length > 0) {
+          alert(`投稿に失敗しました。\n\n${result.errors.join("\n")}`);
+        } else {
+          alert("投稿に失敗しました。");
+        }
+
+        // エラーを throw して catch に渡す
         throw new Error(result.errors?.join(", ") || "投稿に失敗しました");
       }
     } catch (error) {
       loading.classList.remove("active");
-      alert("投稿に失敗しました。");
       console.error("投稿エラー:", error);
+
+      // ❗ NGワードや既知のエラーでなければ予期しないエラーとして alert
+      if (!error.message.includes("NG") && !error.message.includes("失敗")) {
+        alert("予期しないエラーが発生しました。⚠️NGワードが含まれている可能性があります。");
+      }
     }
   });
 };
 
-
+// カード形式のラジオボタン初期化
 const initCardRadios = () => {
   function refreshCardsByName(name) {
     const group = document.querySelectorAll(
@@ -94,16 +110,23 @@ const initCardRadios = () => {
   names.forEach((name) => refreshCardsByName(name));
 };
 
+// 公開・コメント不可制御アラート
 const setupVisibilityAlert = () => {
-  const publicRadios = document.querySelectorAll('input[name="post[is_public]"]');
-  const commentRadios = document.querySelectorAll('input[name="post[comment_allowed]"]');
+  const publicRadios = document.querySelectorAll(
+    'input[name="post[is_public]"]'
+  );
+  const commentRadios = document.querySelectorAll(
+    'input[name="post[comment_allowed]"]'
+  );
   if (!publicRadios.length || !commentRadios.length) return;
 
   const checkInvalidCombo = () => {
     const isPublic =
-      document.querySelector('input[name="post[is_public]"]:checked')?.value === "true";
+      document.querySelector('input[name="post[is_public]"]:checked')?.value ===
+      "true";
     const commentAllowed =
-      document.querySelector('input[name="post[comment_allowed]"]:checked')?.value === "true";
+      document.querySelector('input[name="post[comment_allowed]"]:checked')
+        ?.value === "true";
 
     console.log(`公開=${isPublic} / コメント=${commentAllowed}`);
     if (!isPublic && commentAllowed) {
@@ -119,16 +142,16 @@ const setupVisibilityAlert = () => {
   };
 
   [...publicRadios, ...commentRadios].forEach((r) => {
-    r.removeEventListener("change", checkInvalidCombo); 
+    r.removeEventListener("change", checkInvalidCombo);
     r.addEventListener("change", checkInvalidCombo);
   });
 
   checkInvalidCombo();
 };
 
+// 初期化
 document.addEventListener("turbo:load", () => {
   initPostForm();
   initCardRadios();
   setupVisibilityAlert();
-
 });

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -6,12 +6,29 @@ class Comment < ApplicationRecord
   has_many :flowers, as: :flowerable, dependent: :destroy
 
   validates :content, presence: true
+  validate :content_does_not_include_ng_words
 
+  # コメントに含まれるNGワードをチェック
+  def content_does_not_include_ng_words
+    return unless content.present?
+
+    # config/initializers/ng_words.rb で定義した NG_WORDS 配列を読み込む
+    ng_words = defined?(NG_WORDS) ? NG_WORDS : []
+    matched_words = ng_words.select { |word| content.include?(word) }
+
+    if matched_words.any?
+      errors.add(:content, "に使用できない単語が含まれています: #{matched_words.join(', ')}")
+    end
+  end
+
+  # いいね（花）の数を返す
   def flower_count
     self[:flowers_count] || 0
   end
 
+  # 指定ユーザーが花をつけたかどうか
   def flowered_by?(user)
     flowers.exists?(user_id: user.id)
   end
 end
+

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -9,27 +9,39 @@
     <div class="bg-white rounded-3xl shadow-lg p-8">
       <%= form_with model: @post, local: true, url: post_path(@post, from: params[:from]) do |f| %>
 
+        <!-- 📮 投函する箱（編集時は選択不可） -->
         <div class="mb-8 relative z-10">
-          <label class="block text-lg font-bold text-gray-800 mb-4">📮 投函する箱を選んでください</label>
-          <div class="grid md:grid-cols-3 gap-4">
+          <label class="block text-lg font-bold text-gray-800 mb-4">📮 投函する箱</label>
+
+          <!-- 編集時はpost_typeを変更できないようにする -->
+          <%= f.hidden_field :post_type, value: @post.post_type %>
+
+          <div class="grid md:grid-cols-3 gap-4 opacity-60 pointer-events-none">
             <% { future: ["🌱", "未来宣言箱", "目標や決意を投函"],
                  organize: ["🌈", "心の整理箱", "気持ちを書き出す"],
                  thanks: ["💌", "感謝箱", "感謝の気持ちを記録"] }.each do |type, (icon, title, desc)| %>
-              <label class="relative cursor-pointer select-none">
+
+              <label class="relative select-none">
+                <!-- 触れないラジオ（表示のためだけにcheckedを入れる） -->
                 <%= f.radio_button :post_type, type,
-                      class: "absolute inset-0 opacity-0 cursor-pointer peer z-20",
+                      class: "absolute inset-0 opacity-0 peer z-20",
                       checked: @post.post_type == type.to_s,
-                      required: true %>
-                <div class="card-ui text-center border-3 border-gray-200 rounded-xl p-4 transition-all bg-white hover:bg-orange-50 peer-checked:border-orange-400 peer-checked:ring-2 peer-checked:ring-orange-200">
+                      disabled: true %>
+
+                <div class="card-ui text-center border-3 border-gray-200 rounded-xl p-4 transition-all bg-white peer-checked:border-orange-400 peer-checked:ring-2 peer-checked:ring-orange-200">
                   <div class="text-5xl mb-3"><%= icon %></div>
                   <h3 class="text-xl font-bold mb-2"><%= title %></h3>
                   <p class="text-sm text-gray-600"><%= desc %></p>
                 </div>
               </label>
+
             <% end %>
           </div>
+
+          <p class="text-sm text-gray-500 mt-2">※ 投稿箱は変更できません</p>
         </div>
 
+        <!-- 💬 コメント設定 -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">💬 コメント設定</label>
           <div class="flex gap-4">
@@ -55,6 +67,7 @@
           </div>
         </div>
 
+        <!-- 🔒 公開設定 -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">🔒 公開設定</label>
           <div class="flex gap-4">
@@ -80,6 +93,7 @@
           </div>
         </div>
 
+        <!-- タイトル -->
         <div class="mb-8">
           <label class="block text-lg font-bold text-gray-800 mb-4">🖋 タイトル</label>
           <%= f.text_field :title,
@@ -89,6 +103,7 @@
           <p class="text-right text-sm text-gray-500 mt-2">100文字以内</p>
         </div>
 
+        <!-- 本文 -->
         <div class="mb-8">
           <label class="block text-lg font-bold text-gray-800 mb-4">📝 本文</label>
           <%= f.text_area :body,
@@ -101,6 +116,7 @@
           </div>
         </div>
 
+        <!-- 匿名 -->
         <div class="mb-8">
           <label class="flex items-center gap-3 cursor-pointer p-4 bg-gray-50 rounded-xl hover:bg-gray-100 transition">
             <%= f.check_box :is_anonymous,
@@ -115,6 +131,7 @@
           </label>
         </div>
 
+        <!-- エラー -->
         <% if @post.errors.any? %>
           <div class="mb-8 p-4 bg-red-50 border-l-4 border-red-500 rounded">
             <h3 class="font-bold text-red-700 mb-2">エラーが発生しました</h3>
@@ -126,8 +143,10 @@
           </div>
         <% end %>
 
+        <!-- ボタン -->
         <div class="flex justify-center gap-4">
           <%= f.submit "更新する", class: "px-12 py-3 bg-gradient-to-r from-blue-400 to-blue-500 text-white text-lg font-bold rounded-full hover:shadow-xl transition transform hover:scale-105 cursor-pointer" %>
+
           <% if params[:from] == 'mypage' %>
             <%= link_to "キャンセル", mypage_posts_path, class: "px-8 py-3 bg-gray-200 text-gray-700 font-bold rounded-full hover:bg-gray-300 transition" %>
           <% else %>
@@ -138,6 +157,7 @@
       <% end %>
     </div>
 
+    <!-- 削除ボタン -->
     <div class="mt-8 text-center">
       <%= button_to "この投稿を削除する", post_path(@post, from: params[:from]),
           method: :delete,

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -13,16 +13,20 @@
               data: { turbo: false },
               html: { onsubmit: "return false;" } do |f| %>
 
+        <!-- 📮 投函する箱選択 -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">📮 投函する箱を選んでください</label>
+
           <div class="grid md:grid-cols-3 gap-4">
             <% { future: ["🌱", "未来宣言箱", "目標や決意を投函"],
                  organize: ["🌈", "心の整理箱", "気持ちを書き出す"],
                  thanks: ["💌", "感謝箱", "感謝の気持ちを記録"] }.each do |type, (icon, title, desc)| %>
+
               <label class="relative cursor-pointer select-none">
                 <%= f.radio_button :post_type, type,
                       class: "absolute inset-0 opacity-0 cursor-pointer peer z-20 post-type-radio",
                       required: true %>
+
                 <div class="card-ui text-center border-2 border-gray-200 rounded-xl p-4 transition-all
                             peer-checked:border-orange-400 peer-checked:ring-2 peer-checked:ring-orange-200
                             bg-white hover:bg-orange-50">
@@ -31,10 +35,16 @@
                   <p class="text-sm text-gray-600"><%= desc %></p>
                 </div>
               </label>
+
             <% end %>
           </div>
-        </div>
 
+          <!-- ✨ 注意書き -->
+          <p class="text-sm text-gray-500 mt-2">※ 投稿箱は投函後に変更できません</p>
+        </div>
+        <!-- /投函する箱 -->
+
+        <!-- 💬 コメント設定 -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">💬 コメント設定</label>
           <div class="flex gap-4">
@@ -67,6 +77,7 @@
           <%= f.hidden_field :comment_allowed, id: "comment_allowed", value: true %>
         </div>
 
+        <!-- 🔒 公開設定 -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">🔒 公開設定</label>
           <div class="flex gap-4">
@@ -95,6 +106,7 @@
           </div>
         </div>
 
+        <!-- 🖋 タイトル -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">🖋 タイトル</label>
           <%= f.text_field :title,
@@ -105,6 +117,7 @@
           <p class="text-right text-sm text-gray-500 mt-2">100文字以内</p>
         </div>
 
+        <!-- 📝 本文 -->
         <div class="mb-8 relative z-10">
           <label class="block text-lg font-bold text-gray-800 mb-4">📝 本文</label>
           <%= f.text_area :body,
@@ -118,6 +131,7 @@
           </p>
         </div>
 
+        <!-- 匿名設定 -->
         <div class="mb-8">
           <label class="flex items-center gap-3 cursor-pointer p-4 bg-gray-50 rounded-xl hover:bg-gray-100 transition">
             <%= f.check_box :is_anonymous,
@@ -131,6 +145,7 @@
           </label>
         </div>
 
+        <!-- 送信ボタン -->
         <div class="flex justify-center gap-4 relative z-10">
           <%= f.submit "投函する 📮",
                 class: "px-12 py-3 bg-gradient-to-r from-orange-400 to-pink-400 text-white text-lg font-bold rounded-full hover:shadow-xl transition transform hover:scale-105" %>
@@ -141,6 +156,7 @@
   </div>
 </main>
 
+<!-- 投函アニメーション -->
 <div id="loadingScreen" class="loading-screen">
   <div class="postbox-animation">
     <div class="letter"></div>
@@ -149,6 +165,7 @@
   </div>
 </div>
 
+<!-- 完了画面 -->
 <div id="completionScreen" class="completion-screen">
   <div class="completion-content">
     <div class="checkmark"></div>

--- a/config/initializers/ng_words.rb
+++ b/config/initializers/ng_words.rb
@@ -1,21 +1,21 @@
 # config/initializers/ng_words.rb
 
 NG_WORDS = %w[
-不適切 危険 卑猥 暴力 差別 嫌がらせ 下品 侮辱 中傷 暴言 罵倒 わいせつ 淫ら 露骨 乱暴 下ネタ 性的 嫌悪 悪口 罵声 嘲笑 強姦 殺害
-暴行 殴打 脅迫 犯罪 麻薬 薬物 性犯罪 違法 飲酒 喫煙 自傷 自殺 死 犯罪予告 暴力行為 差別用語 反社会的 ヘイト 過激 卑劣 嘘 虚偽 扇動
+不適切 卑猥 暴力 差別 嫌がらせ 下品 侮辱 中傷 暴言 罵倒 わいせつ 淫ら 露骨 乱暴 下ネタ 性的 嫌悪 悪口 罵声 嘲笑 強姦 殺害
+暴行 殴打 脅迫 犯罪 麻薬 薬物 性犯罪 違法  喫煙 自傷 自殺 死 犯罪予告 暴力行為 差別用語 反社会的 ヘイト 過激 卑劣 嘘 虚偽 扇動
 過激表現 暴言中傷 迷惑行為 不快 嫌気 悪質 不愉快 危険行為 危険物 犯罪行為 卑猥表現 侮辱行為 卑劣行為 暴力表現 脅迫行為 性的表現 性的表現 下品表現 卑猥行為
 過激言動 暴力言動 脅迫言動 差別言動 侮辱言動 中傷言動 嫌がらせ言動 不適切言動 不快発言 不謹慎 不謹慎表現 性的嫌がらせ 性的暴力 性的差別 下品発言 下ネタ発言 卑猥発言
-過激表現発言 暴力発言 脅迫発言 差別発言 嘲笑発言 虐待 虐殺 暴動 テロ 違法薬物 犯罪組織 暴力団 麻薬取引 強盗 殺人 監禁 拉致 拷問
-暴言行為 嘘情報 デマ 偽情報 淫行 強制性交 ポルノ 色情 撲殺 誹謗 中傷 英語_swear fuck shit bitch asshole bastard slut dick pussy rape
-cock cum blowjob handjob masturbate hentai porn sex nude naked fucker cocksucker asshole motherfucker
+過激表現発言 暴力発言 脅迫発言 差別発言 嘲笑発言 虐待 虐殺 暴動 テロ 違法薬物 犯罪組織 暴力団 麻薬取引 強盗 殺人 監禁 拉致 拷問 エロ タヒ ○にたい 生きていたくない 氏にたい
+殺して ムラムラ 暴言行為 嘘情報 デマ 偽情報 淫行 強制性交 ポルノ 色情 撲殺 誹謗 中傷 swear fuck shit bitch asshole bastard slut dick pussy rape
+blowjob handjob masturbate hentai porn sex nude naked fucker cocksucker asshole motherfucker
 bitchy slutty whore horny hornyfuck fucked fucking kill death murder torture rape gangrape pedo pedophile childporn
-drugs cocaine heroin meth marijuana alcohol cigarettes smoking suicide selfharm bomb terror terrorist attack shooting
-killings behead decapitate violent beat abuse assault molest harass stalk fraud scam cheat ripoff
+drugs cocaine heroin meth marijuana suicide selfharm terror terrorist
+killings behead decapitate violent abuse assault molest harass stalk fraud scam cheat ripoff
 insult insulted degrading humiliation humiliation act offensive vulgar disgusting disgustingness nasty nastyword
 racist sexist homophobic xenophobic hate slur profanity offensiveword inappropriate obscene indecent
-pervert perverted freak freaky creeper creep creepy gross nasty evil malicious nastyass evilass
+pervert perverted freak freaky creeper nasty evil malicious nastyass evilass
 slutbag whorebag dirty whoremonger nigger chink jap spic kike fag dyke queer tranny trannyhate trannykill
 pedo childmolester kiddiefuck kiddieporn necro necrophilia bestiality zoophilia animalporn incest taboo
 voyeur voyeurism peeping tom spy hacker virus malware trojan phishing scam botnet exploit hackerattack
-cheater liar liarliar lying false falseinfo fake propaganda spam troll griefing annoying bother disturb
+cheater liar liarliar lying false falseinfo fake propaganda spam troll griefing annoying bother 
 ]

--- a/config/locales/posts.ja.yml
+++ b/config/locales/posts.ja.yml
@@ -7,6 +7,8 @@ ja:
     alerts:
       unauthorized: "権限がありません。"
       private_post: "この投稿は非公開です。"
+      ng_word: "投稿に使用できない単語が含まれています。"
+      failed: "投稿に失敗しました。"
     buttons:
       new: "新規投稿"
       edit: "編集"
@@ -21,6 +23,8 @@ ja:
       deleted: "コメントを削除しました。"
     alerts:
       unauthorized: "権限がありません。"
+      ng_word: "コメントに使用できない単語が含まれています。"
+      failed: "コメントの投稿に失敗しました。コメントに使用できない単語が含まれている可能性があります。"
     buttons:
       edit: "編集"
       delete: "削除"


### PR DESCRIPTION
投稿後に選択した投稿箱（post_type）を変更できないようにするため、フロントエンドとバックエンドの双方で編集禁止の仕組みを実装しています。まず編集画面では、post_type のラジオボタンに disabled と pointer-events-none を付与し、見た目は保持したままユーザーが操作できない状態にしました。また、f.hidden_field :post_type を追加し、編集時には既存の値のみをサーバーへ送信するようにしています。

さらにセキュリティ対策として、PostsController では作成（create）時と更新（update）時で Strong Parameters を分け、post_params_for_create のみ post_type を許可し、post_params_for_update では post_type を受け取らないようにしています。加えて、更新処理前に呼ばれる prepare_updated_params 内で updated.delete(:post_type) を実行し、hidden_field の改ざんや悪意あるリクエストによって post_type を書き換えられることを防いでいます。