### PR TITLE
OGP改修

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   def set_default_meta
     @page_title = 'cocopos - 心のポスト(目安箱)'
     @page_description = '心の記録を花のように咲かせる。未来宣言箱・心の整理箱・感謝箱で気持ちを残せるアプリです。'
-    @page_image_path = 'ogp.jpg'
+    @page_image_path = 'cocopos.ogp.jpg'
 
     @page_type = 'website'
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -55,7 +55,7 @@ module ApplicationHelper
   end
 
   def resolved_image_url(page_image_path)
-    path = page_image_path.presence || '/ogp.jpg'
-    "#{request.base_url}#{path}"
+    image = page_image_path.presence || 'cocopos.ogp.jpg'
+    image_url(image)
   end
 end


### PR DESCRIPTION
OGP画像URLの生成処理を改修しました。これまでは resolved_image_url 内で request.base_url とパス文字列を手動で連結していたため、https://www.cocopos.netogp.jpg のような不正なURLが生成される可能性がありました。また、環境によっては古い fingerprint 付きアセットURLを参照してしまい、OGP画像の取得に失敗する要因にもなっていました。今回の改修では、デフォルト画像を cocopos.ogp.jpg に統一し、URL生成を Rails の image_url に委譲しています。これにより Propshaft が各環境に応じた正しいアセットURLを解決できるようになり、OGPおよび Twitter Card の画像参照が安定します。ページ本体は正常に表示されていたため、問題の本質は画面描画ではなく meta タグ内の画像URL生成処理にありました。本改修はその根本原因に対する対応です